### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -40,5 +40,5 @@ appropriate to the circumstances. Maintainers are obligated to maintain confiden
 with regard to the reporter of an incident.
 
 This Code of Conduct is adapted from the
-http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
-http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]
+https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
+https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]

--- a/spring-cloud-starter-stream-sink-task-launcher-dataflow/README.adoc
+++ b/spring-cloud-starter-stream-sink-task-launcher-dataflow/README.adoc
@@ -1,7 +1,7 @@
 //tag::ref-doc[]
 = TaskLauncher Data Flow Sink
 
-This application launches a registered task application using the Data Flow Server http://docs.spring.io/spring-cloud-dataflow/docs/current/reference/htmlsingle/#api-guide-resources-task-executions-launching[REST API].
+This application launches a registered task application using the Data Flow Server https://docs.spring.io/spring-cloud-dataflow/docs/current/reference/htmlsingle/#api-guide-resources-task-executions-launching[REST API].
 
 == Input
 
@@ -61,7 +61,7 @@ for launch requests but will pause when the SCDF server's concurrent task execut
 .dataflow.task
 .maximum-concurrent-tasks`
 is reached (see the
-http://docs.spring.io/spring-cloud-dataflow/docs/current/reference/htmlsingle/#spring-cloud-dataflow-task-limit-concurrent-executions[reference docs] for more details).
+https://docs.spring.io/spring-cloud-dataflow/docs/current/reference/htmlsingle/#spring-cloud-dataflow-task-limit-concurrent-executions[reference docs] for more details).
 
 When the number of running tasks drops below this limit message polling resumes. This is intended to prevent
 the SCDF deployer's deployment platform from running out of resources under heavy task load. The poller is


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://docs.spring.io/spring-cloud-dataflow/docs/current/reference/htmlsingle/ with 2 occurrences migrated to:  
  https://docs.spring.io/spring-cloud-dataflow/docs/current/reference/htmlsingle/ ([https](https://docs.spring.io/spring-cloud-dataflow/docs/current/reference/htmlsingle/) result 200).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).

# Ignored
These URLs were intentionally ignored.

* http://localhost with 1 occurrences
* http://localhost:9393 with 1 occurrences