### PR TITLE
Fix 36

### DIFF
--- a/apps/task-launcher-dataflow-sink-rabbit/pom.xml
+++ b/apps/task-launcher-dataflow-sink-rabbit/pom.xml
@@ -172,7 +172,7 @@
 									<exec>
 										<arg>java</arg>
 										<arg>-jar</arg>
-										<arg>/maven/task-launcher-dataflow-sink-kafka.jar</arg>
+										<arg>/maven/task-launcher-dataflow-sink-rabbit.jar</arg>
 									</exec>
 								</entryPoint>
 								<assembly>


### PR DESCRIPTION
The docker image for rabbit was incorrectly configured to run the jar file for kafka (which does not exist in the docker image). Corrected to use the jar file with the correct name for rabbit.
Fixes issue spring-cloud-stream-app-starters#36