### PR TITLE
Upgrade micrometer deps to work with boot 2.3.x

### DIFF
--- a/apps/task-launcher-dataflow-sink-kafka/pom.xml
+++ b/apps/task-launcher-dataflow-sink-kafka/pom.xml
@@ -29,9 +29,10 @@
 	<properties>
 		<skipTests>true</skipTests>
 		<java.version>1.8</java.version>
-		<spring-cloud.version>Hoxton.SR1</spring-cloud.version>
+		<spring-cloud.version>Hoxton.SR9</spring-cloud.version>
 		<spring-cloud-dataflow.version>2.4.0.RELEASE</spring-cloud-dataflow.version>
 		<cloud-connector.version>2.0.6.RELEASE</cloud-connector.version>
+		<micrometer.version>1.5.3</micrometer.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 	<dependencyManagement>
@@ -56,7 +57,7 @@
 		<dependency>
 			<groupId>org.springframework.cloud.stream.app</groupId>
 			<artifactId>app-starters-micrometer-common</artifactId>
-			<version>2.1.4.RELEASE</version>
+			<version>2.1.5.RELEASE</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud.stream.app</groupId>
@@ -66,17 +67,17 @@
 		<dependency>
 			<groupId>io.micrometer</groupId>
 			<artifactId>micrometer-registry-datadog</artifactId>
-			<version>1.3.5</version>
+			<version>${micrometer.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>io.micrometer</groupId>
 			<artifactId>micrometer-registry-influx</artifactId>
-			<version>1.3.5</version>
+			<version>${micrometer.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>io.micrometer</groupId>
 			<artifactId>micrometer-registry-prometheus</artifactId>
-			<version>1.3.5</version>
+			<version>${micrometer.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>io.micrometer.prometheus</groupId>
@@ -116,7 +117,7 @@
 		<dependency>
 			<groupId>io.micrometer</groupId>
 			<artifactId>micrometer-registry-wavefront</artifactId>
-			<version>1.3.5</version>
+			<version>${micrometer.version}</version>
 		</dependency>
 
 		<dependency>

--- a/apps/task-launcher-dataflow-sink-rabbit/pom.xml
+++ b/apps/task-launcher-dataflow-sink-rabbit/pom.xml
@@ -29,9 +29,10 @@
 	<properties>
 		<skipTests>true</skipTests>
 		<java.version>1.8</java.version>
-		<spring-cloud.version>Hoxton.SR1</spring-cloud.version>
+		<spring-cloud.version>Hoxton.SR9</spring-cloud.version>
 		<spring-cloud-dataflow.version>2.4.0.RELEASE</spring-cloud-dataflow.version>
 		<cloud-connector.version>2.0.6.RELEASE</cloud-connector.version>
+		<micrometer.version>1.5.3</micrometer.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 	<dependencyManagement>
@@ -56,7 +57,7 @@
 		<dependency>
 			<groupId>org.springframework.cloud.stream.app</groupId>
 			<artifactId>app-starters-micrometer-common</artifactId>
-			<version>2.1.4.RELEASE</version>
+			<version>2.1.5.RELEASE</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud.stream.app</groupId>
@@ -66,17 +67,17 @@
 		<dependency>
 			<groupId>io.micrometer</groupId>
 			<artifactId>micrometer-registry-datadog</artifactId>
-			<version>1.3.5</version>
+			<version>${micrometer.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>io.micrometer</groupId>
 			<artifactId>micrometer-registry-influx</artifactId>
-			<version>1.3.5</version>
+			<version>${micrometer.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>io.micrometer</groupId>
 			<artifactId>micrometer-registry-prometheus</artifactId>
-			<version>1.3.5</version>
+			<version>${micrometer.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>io.micrometer.prometheus</groupId>
@@ -116,7 +117,7 @@
 		<dependency>
 			<groupId>io.micrometer</groupId>
 			<artifactId>micrometer-registry-wavefront</artifactId>
-			<version>1.3.5</version>
+			<version>${micrometer.version}</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Resolves start up error when deployed with SCDF configured for prometheus:
```
`Caused by: java.lang.ClassNotFoundException: io.micrometer.prometheus.HistogramFlavor
	at java.net.URLClassLoader.findClass(URLClassLoader.java:382) ~[na:1.8.0_192]
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424) ~[na:1.8.0_192]
	at org.springframework.boot.loader.LaunchedURLClassLoader.loadClass(LaunchedURLClassLoader.java:151) ~[task-launcher-dataflow-sink-kafka.jar:1.1.4.RELEASE]
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357) ~[na:1.8.0_192]
	... 109 common frames omitted`
```